### PR TITLE
Update RESTCONF to account for no separate private candidate datastore.

### DIFF
--- a/draft-ietf-netconf-privcand-05.xml
+++ b/draft-ietf-netconf-privcand-05.xml
@@ -284,7 +284,7 @@
       <section>
         <name>When is a private candidate destroyed</name>
         <t>A private candidate is valid for the duration of the NETCONF session,
-        or the duration of the existence of the RESTCONF client.  Issuing
+        or the duration of the RESTCONF request.  Issuing
         a &lt;commit&gt; operation will not close the private candidate but will issue an
         implicit &lt;update&gt; operation resyncing changes from the running configuration.
         More details on this later in this document.</t>
@@ -340,14 +340,8 @@ urn:ietf:params:netconf:capability:private-candidate:1.0
         </section>
         <section>
           <name>RESTCONF client</name>
-	  <t>RESTCONF does not provide a mechanism for the client to advertise a capability.
-    Therefore when a RESTCONF server advertises the :private-candidate capability, the
-    decision of whether to use a private candidate depends on whether a datastore is
-    explicitly referenced in the request using the RESTCONF extensions for NMDA
-	  <xref target="RFC8527"/>.</t>
-      <section>
-        <name>Datastore is not explicitly referenced</name>
-	    <t>When the server advertises the :private-candidate capability and the client
+	  <t>RESTCONF does not provide a mechanism for the client to advertise a capability
+    Therefore when a RESTCONF server advertises the :private-candidate capability, and the client
          references the "{+restconf}/data" resource described in
          <xref target="RFC8040" sectionFormat="of" section="3.3.1" />,
          all edits are made to the client's private candidate, and the private candidate
@@ -355,27 +349,6 @@ urn:ietf:params:netconf:capability:private-candidate:1.0
         <t>This ensures backwards compatibility with RESTCONF clients that are not aware of
          private candidates, because those clients will expect their changes to be
          committed immediately.</t>
-      </section>
-      <!-- TODO: Check whether this section is needed now
-      <section>
-        <name>Private candidate datastore is referenced in the request</name>
-	    <t>When the private-candidate datastore is explicitly referenced as an NMDA datastore,
-         edits are made to the client's private candidate, but the private candidate is not
-         committed.  To commit the changes, the client must explicitly send a commit request.</t>
-        <t>A commit request is of the form "{+restconf}/operations/ietf-netconf:commit",
-         using the API described in <xref target="RFC8040" sectionFormat="of" section="3.3.2" />.
-         The semantics are identical to the NETCONF &lt;commit&gt; operation.</t>
-        <t>Similarly, the client can perform ietf-netconf:discard-changes,
-         ietf-netconf:validate, and ietf-netconf:cancel-commit operations (if the appropriate
-         capabilities are implemented).  The semantics are identical to NETCONF.</t>
-      </section>
-      -->
-      <section>
-        <name>Identifying the private candidate datastore</name>
-        <t>Each RESTCONF client has its own private candidate datastore.  The client
-         (and hence the private candidate datastore) is identified using the mechanism
-         described in <xref target="RFC8040" sectionFormat="of" section="2.5" />.</t>
-      </section>
 	</section>
       </section>
       <section>
@@ -972,6 +945,12 @@ urn:ietf:params:netconf:capability:private-candidate:1.0
             datastore.  If no private candidate configuration has been created, one will be 
             created at this point.</t>
           </section>
+          <section>
+            <name>&lt;copy-config&gt;</name>
+            <t>When performing a &lt;copy-config&gt; operation with the candidate configuration datastore
+            as the source or target, the private candidate will be used.  If no private candidate
+            configuration has been created, one will be created at this point.</t>
+          </section>
           <section anchor="section_updates_to_get_data">
             <name>&lt;get-data&gt;</name>
             <t>Performing a &lt;get-data&gt; operation with the candidate configuration datastore
@@ -1071,7 +1050,6 @@ urn:ietf:params:netconf:capability:private-candidate:1.0
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.5717.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8040.xml"/>
         <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8526.xml"/>
-        <xi:include href="https://www.rfc-editor.org/refs/bibxml/reference.RFC.8527.xml"/>
         <!-- The recommended and simplest way to include a well known reference -->
       </references>
       <references>

--- a/draft-ietf-netconf-privcand-05.xml
+++ b/draft-ietf-netconf-privcand-05.xml
@@ -340,11 +340,12 @@ urn:ietf:params:netconf:capability:private-candidate:1.0
         </section>
         <section>
           <name>RESTCONF client</name>
-	  <t>RESTCONF does not provide a mechanism for the client to advertise a capability
-    Therefore when a RESTCONF server advertises the :private-candidate capability, and the client
-         references the "{+restconf}/data" resource described in
-         <xref target="RFC8040" sectionFormat="of" section="3.3.1" />,
-         all edits are made to the client's private candidate, and the private candidate
+	  <t>RESTCONF does not provide a mechanism for the client to advertise a capability.
+    Therefore when a RESTCONF server advertises the :private-candidate capability, all
+         client requests will use a private candidate when the client references
+         the "{+restconf}/data" resource described in
+         <xref target="RFC8040" sectionFormat="of" section="3.3.1" />.
+         All edits are made to the client's private candidate, and the private candidate
          is automatically committed.</t>
         <t>This ensures backwards compatibility with RESTCONF clients that are not aware of
          private candidates, because those clients will expect their changes to be
@@ -991,6 +992,18 @@ urn:ietf:params:netconf:capability:private-candidate:1.0
             comparing the current private candidate configuration with the same
             private candidate configuration at the time this private candidate was initially created.</t>
           </section>
+          </section>
+          <section>
+            <name>&lt;lock&gt;</name>
+            <t>The behaviour of the &lt;lock&gt; operation is updated such that
+            locking the candidate configuration datastore will lock that session's private
+            candidate configuration datastore only.</t>
+          </section>
+          <section>
+            <name>&lt;unlock&gt;</name>
+            <t>The behaviour of the &lt;unlock&gt; operation is updated such that
+            unlocking the candidate configuration datastore will unlock that session's private
+            candidate configuration datastore only.</t>
           </section>
           <section>
             <name>&lt;delete-config&gt;</name>

--- a/draft-ietf-netconf-privcand-05.xml
+++ b/draft-ietf-netconf-privcand-05.xml
@@ -89,10 +89,10 @@
 		 is, in many situations, also undesirable.  <br/><br/>
 
 		 Many network devices support candidate configurations within the CLI interface, 
-     where a user (machine or otherwise) is able to edit a personal copy of a device's 
+     where a user (machine or otherwise) is able to edit a self-contained copy of a device's 
      configuration without blocking other users from doing so.<br/><br/>
 	 
-	     This document details the extensions to the NETCONF protocol in order to support
+	     This document specifies the extensions to the NETCONF protocol in order to support
 	     the use of private candidates.  It also describes how the RESTCONF protocol can be
 	     used on a system that implements private candidates.</t>
       <section>


### PR DESCRIPTION
Add a section covering <copy-config> on private candidate.